### PR TITLE
Fix help of `snage create`

### DIFF
--- a/packages/snage/src/command/common.ts
+++ b/packages/snage/src/command/common.ts
@@ -1,3 +1,6 @@
 export interface DefaultCli {
     config: string;
 }
+export const DefaultSnageConfig = '.snage.yaml';
+export const ConfigParameterName = 'config';
+export const EnvPrefix = 'SNAGE';

--- a/packages/snage/src/command/create.ts
+++ b/packages/snage/src/command/create.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import {DefaultCli} from './common';
+import {DefaultCli, DefaultSnageConfig, ConfigParameterName, EnvPrefix} from './common';
 import {validateFileNameSchema} from '../create/validators';
 import {isLeft} from 'fp-ts/lib/Either';
 import {addToYargs, buildLogParameters} from '../create/consoleParamsReader';
@@ -7,12 +7,22 @@ import {generateChangeLogFile} from '../create/changelogFileWriter';
 import {extractFieldsFromFileName} from '../create/genChangelog';
 import {loadConfig} from '../config/load';
 
+// We cannot use yargs.argv because it will abort the building of the parameters.
+// Sadly we need the config from the parameters to build the arguments.
+// Thus, we manually parse the config parameter.
+const uglyGetConfig = (): string => {
+    const cfgIdx = process.argv.findIndex((arg) => arg === `--${ConfigParameterName}`);
+    if (cfgIdx !== -1 && process.argv.length > cfgIdx + 1) {
+        return process.argv[cfgIdx + 1];
+    }
+    return process.env[`${EnvPrefix}_${ConfigParameterName.toUpperCase()}`] ?? DefaultSnageConfig;
+};
+
 export const create: yargs.CommandModule<DefaultCli, DefaultCli> = {
     command: 'create',
     describe: 'Create a change log file.',
     builder: (y) => {
-        const {config: configFile} = y.argv;
-        const config = loadConfig(configFile);
+        const config = loadConfig(uglyGetConfig());
         const fileNames: string[] = extractFieldsFromFileName(config);
         const fileNameIsValid = validateFileNameSchema(config, fileNames);
         if (isLeft(fileNameIsValid)) {

--- a/packages/snage/src/index.ts
+++ b/packages/snage/src/index.ts
@@ -3,6 +3,7 @@ import {serve} from './command/serve';
 import {init} from './command/init';
 import {lint} from './command/lint';
 import {create} from './command/create';
+import {DefaultSnageConfig, ConfigParameterName, EnvPrefix} from './command/common';
 
 const handleExitSignal = (): void => process.exit(1);
 
@@ -10,10 +11,10 @@ process.on('SIGINT', handleExitSignal);
 process.on('SIGTERM', handleExitSignal);
 
 yargs
-    .string('config')
-    .describe('config', 'Path to the snage config.')
-    .default('config', '.snage.yaml')
-    .env('SNAGE')
+    .string(ConfigParameterName)
+    .describe(ConfigParameterName, 'Path to the snage config.')
+    .default(ConfigParameterName, DefaultSnageConfig)
+    .env(EnvPrefix)
     .command(serve)
     .command(create)
     .command(init)


### PR DESCRIPTION
```
changelog/packages/snage fix-create-help✓ λ yarn dev create  --config "../../.snage.yaml"   --help
yarn run v1.22.4
warning package.json: No license field
$ ts-node src/index.ts create --config ../../.snage.yaml --help
index.ts create

Create a change log file.

Options:
  --version                                                             [string]
  --config          Path to the snage config.  [string] [default: ".snage.yaml"]
  --help            Show help                                          [boolean]
  --noWizard, --nw  Prevents the wizard from starting when fields aren't set.
                    Options are:
                    t - fills all missing required fields with the needed data
                    type as placeholder
                    to - fills all missing required and optional fields with the
                    needed data type as placeholder
                    if no option is provided, the fields will simply be missing,
                    but must be added per hand to obtain a valid change log
                                                                        [string]
  --issue                                                               [string]
  --type                                                                [string]
  --audience                                                            [string]
  --date                                                                [string]
  --components                                                           [array]
```