### PR TITLE
Upload snage release artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           tar -cvzf snage-${VERSION}.tar.gz -C packages/snage/build snage.js ui
-          RELEASE_ID=$(curl "https://api.github.com/repos/FACT-Finder/snage/releases/tags/${VERSION}" | jq '.id')
+          RELEASE_ID=$(curl "https://api.github.com/repos/FACT-Finder/snage/releases/tags/v${VERSION}" | jq '.id')
           curl \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Content-type: application/gzip" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,18 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create release artifact
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tar -cvzf snage-${VERSION}.tar.gz -C packages/snage/build snage.js ui
+          RELEASE_ID=$(curl "https://api.github.com/repos/FACT-Finder/snage/releases/tags/${VERSION}" | jq '.id')
+          curl \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Content-type: application/gzip" \
+            --data-binary @snage-${VERSION}.tar.gz \
+            "https://uploads.github.com/repos/FACT-Finder/snage/releases/${RELEASE_ID}/assets?name=snage-${VERSION}.tar.gz"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Archlinux User Repository
         if: startsWith(github.ref, 'refs/tags/v')
         run: |


### PR DESCRIPTION
Ich bin nicht so sicher, dass es klappt. Die URLs stimmen und ich habe manuell das Artifakt für v0.0.13 hochgeladen. Ich bin aber nicht sicher, ob mit `GITHUB_TOKEN`, `VERSION` und dem multi-line curl-Aufruf alles passt. `jq` und `curl` sind jedenfalls vorhanden.
Das Artifakt könnten wir dann im aur-Package verwenden, damit das nicht so lange bauen muss.