### PR TITLE
Use backwards compatible git command in git-date provider

### DIFF
--- a/packages/snage/src/provider/git-date.ts
+++ b/packages/snage/src/provider/git-date.ts
@@ -53,7 +53,7 @@ const extractDate = (field: ConvertField, directory: string) => (
     tag: string
 ): TE.TaskEither<string, FieldValue | undefined> =>
     pipe(
-        tryExec(`git log -1 --format=%as ${tag}`, {cwd: directory}),
+        tryExec(`git log -1 --date=short --format=%ad ${tag}`, {cwd: directory}),
         TE.map((date) => date.trim()),
         TE.chainEitherK((date) => E.either.mapLeft(decodeValue(field, date), (errors) => errors.join('\n')))
     );


### PR DESCRIPTION
`git` introduced the `%as` format only in version 2.28, but the git
version in the snage docker image is 2.24.
`git log -1 --date=short --format=%ad` already works in 2.24.