### PR TITLE
Fix set-env usage in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           restore-keys: ${{ runner.os }}-node_modules-
       - run: yarn --frozen-lockfile
       - name: Get Version
-        run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - run: yarn docs build
       - run: yarn lerna run build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           restore-keys: ${{ runner.os }}-node_modules-
       - run: yarn --frozen-lockfile
       - name: Get Version
-        run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - run: yarn lerna run build
         env:
           BUILD_VERSION: ${{ env.VERSION }}
@@ -41,7 +41,7 @@ jobs:
           name: build
           path: packages/snage/build/npm
       - name: Get Version
-        run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Publish Release to Docker and NPM
         run: |
           echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
@@ -89,7 +89,7 @@ jobs:
         with:
           name: build
       - name: Get Version
-        run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Publish to Archlinux User Repository
         run: |
           mkdir $HOME/.ssh


### PR DESCRIPTION
See
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
and
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files