### PR TITLE
Update to JamesIves/github-pages-deploy-action@3.7.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
           name: docs
           path: site
       - name: Deploy Docs
-        uses: JamesIves/github-pages-deploy-action@51f4ac3
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           BRANCH: gh-pages
           FOLDER: site


### PR DESCRIPTION
The old version used the now forbidden `::set-env` command.